### PR TITLE
Fix for x:forEach and x:out using incorrect context across JSPs and TAGs

### DIFF
--- a/src/main/java/org/apache/taglibs/standard/tag/common/xml/XalanUtil.java
+++ b/src/main/java/org/apache/taglibs/standard/tag/common/xml/XalanUtil.java
@@ -51,8 +51,7 @@ public class XalanUtil {
     /**
      * Return the XPathContext to be used for evaluating expressions.
      *
-     * If the child is nested withing a forEach tag its iteration context is used.
-     * Otherwise, a new context is created based on an empty Document.
+     * A new context is created based on an empty Document.
      *
      * @param child the tag whose context should be returned
      * @param pageContext the current page context

--- a/src/main/java/org/apache/taglibs/standard/tag/common/xml/XalanUtil.java
+++ b/src/main/java/org/apache/taglibs/standard/tag/common/xml/XalanUtil.java
@@ -88,7 +88,7 @@ public class XalanUtil {
 					}
 				}
 			} catch (final Exception ex) {
-				throw new RuntimeException("There was an exception thrown inspecting the page context of the parent JSP element", ex)
+				throw new RuntimeException("There was an exception thrown inspecting the page context of the parent JSP element", ex);
 			}
 		}
 

--- a/src/main/java/org/apache/taglibs/standard/tag/common/xml/XalanUtil.java
+++ b/src/main/java/org/apache/taglibs/standard/tag/common/xml/XalanUtil.java
@@ -59,13 +59,6 @@ public class XalanUtil {
      * @return the XPath evaluation context
      */
     public static XPathContext getContext(Tag child, PageContext pageContext) {
-        // if within a forEach tag, use its context
-        ForEachTag forEachTag = (ForEachTag) TagSupport.findAncestorWithClass(child, ForEachTag.class);
-        if (forEachTag != null) {
-            return forEachTag.getContext();
-        }
-
-        // otherwise, create a new context referring to an empty document
         XPathContext context = new XPathContext(false);
         VariableStack variableStack = new JSTLVariableStack(pageContext);
         context.setVarStack(variableStack);


### PR DESCRIPTION
This bug has been documented at https://issues.jboss.org/browse/WFLY-6267, and is demonstrated with the sample project at https://github.com/mcasperson/wildfly_jstl_bug/.

To reproduce, build the WAR from https://github.com/mcasperson/wildfly_jstl_bug/ and deploy to Wildfly 10.0.0.Final. You will see the following exception:

```
        Caused by: javax.xml.transform.TransformerException: Could not resolve XPath variable: $childNode
            at org.apache.taglibs.standard.tag.common.xml.JSTLVariableStack.getVariableOrParam(JSTLVariableStack.java:93)
            at org.apache.xpath.operations.Variable.execute(Variable.java:219)
            at org.apache.xpath.operations.Variable.execute(Variable.java:188)
            at org.apache.xpath.axes.FilterExprIteratorSimple.executeFilterExpr(FilterExprIteratorSimple.java:116)
            at org.apache.xpath.axes.FilterExprWalker.setRoot(FilterExprWalker.java:131)
            at org.apache.xpath.axes.WalkingIterator.setRoot(WalkingIterator.java:157)
            at org.apache.xpath.axes.NodeSequence.setRoot(NodeSequence.java:265)
            at org.apache.xpath.axes.LocPathIterator.execute(LocPathIterator.java:212)
            at org.apache.xpath.XPath.execute(XPath.java:337)
            ... 41 more
```

This PR removes the code that shares contexts with parent ForEachTag's, because it did not respect the scope between a JSP and a TAG.