### PR TITLE
[BZ1312318] :  After upgrading to EAP 6.4.6 some of the attributes are not resolved by x:transform.

### DIFF
--- a/src/main/java/org/apache/taglibs/standard/util/XmlUtil.java
+++ b/src/main/java/org/apache/taglibs/standard/util/XmlUtil.java
@@ -99,7 +99,6 @@ public class XmlUtil {
                     return (SAXTransformerFactory) tf;
                 }
             }, TransformerConfigurationException.class);
-            TRANSFORMER_FACTORY.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, secureProcessing);
         } catch (TransformerConfigurationException e) {
             throw new ExceptionInInitializerError(e);
         }


### PR DESCRIPTION
 After upgrading to EAP 6.4.6 some of the attributes are not resolved by x:transform.