### PR TITLE
[BZ1320747] fix one regression made in https://github.com/jboss/jboss-jstl-api_spec/pull/7

### DIFF
--- a/src/main/java/org/apache/taglibs/standard/tag/common/xml/TransformSupport.java
+++ b/src/main/java/org/apache/taglibs/standard/tag/common/xml/TransformSupport.java
@@ -121,7 +121,7 @@ public abstract class TransformSupport extends BodyTagSupport {
         }
 
         try {
-            t = XmlUtil.newTransformer(source);
+            t = XmlUtil.newTransformer(source, uriResolver);
             t.setURIResolver(uriResolver);
         } catch (TransformerConfigurationException e) {
             throw new JspTagException(e);

--- a/src/main/java/org/apache/taglibs/standard/util/XmlUtil.java
+++ b/src/main/java/org/apache/taglibs/standard/util/XmlUtil.java
@@ -188,10 +188,12 @@ public class XmlUtil {
     /**
      * Create a new Transformer from an XSLT.
      * @param source the source of the XSLT.
+     * @param uriResolver
      * @return a new Transformer
      * @throws TransformerConfigurationException if there was a problem creating the Transformer from the XSLT
      */
-    public static Transformer newTransformer(Source source) throws TransformerConfigurationException {
+    public static Transformer newTransformer(Source source, JstlUriResolver uriResolver) throws TransformerConfigurationException {
+        TRANSFORMER_FACTORY.setURIResolver(uriResolver);
         Transformer transformer = TRANSFORMER_FACTORY.newTransformer(source);
         // Although newTansformer() is not allowed to return null, Xalan does.
         // Trap that here by throwing the expected TransformerConfigurationException.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1320747
As reported issue, previous change broke relative path use in JSTL TransformSupport XSL import. In order to recognize relative path, it should set JstlUriResolver to TRANSFORMER_FACTORY as well like we did before as 

https://github.com/jboss/jboss-jstl-api_spec/pull/7/files?diff=unified#diff-32e4ebc53fc3afe5ff81fb576529db72L186

After that change, current behavior is like: 
https://github.com/jboss/jboss-jstl-api_spec/pull/7/files?diff=unified#diff-32e4ebc53fc3afe5ff81fb576529db72R124
https://github.com/jboss/jboss-jstl-api_spec/pull/7/files?diff=unified#diff-be313f224fb9d64e59801ea349af5c0cR187

I have tested with reproducer in issue, following changes fix it.

This is only a regression in 1.0.x branch, master branch 1.1.x does not have this problem.
